### PR TITLE
Add conversion from decimal to PDecimalValue

### DIFF
--- a/source/PortfolioReader.Business/PortfolioReader.Business.csproj
+++ b/source/PortfolioReader.Business/PortfolioReader.Business.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>netstandard2.1</TargetFramework>
 		<RootNamespace>Toqe.PortfolioReader.Business</RootNamespace>
 		<LangVersion>latest</LangVersion>
 	</PropertyGroup>

--- a/source/PortfolioReader.Business/Protobuf/PortfolioProtobufDataConverter.cs
+++ b/source/PortfolioReader.Business/Protobuf/PortfolioProtobufDataConverter.cs
@@ -36,9 +36,25 @@ namespace Toqe.PortfolioReader.Business.Protobuf
 
         public decimal ConvertDecimalValue(PDecimalValue value)
         {
-            var bigInt = new BigInteger(Enumerable.Repeat((byte)0, 1).Concat(value.Value.AsEnumerable()).Reverse().ToArray());
-            var bigIntDecimal = decimal.Parse(bigInt.ToString(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture);
-            return bigIntDecimal * (decimal)Math.Pow(10, -value.Scale);
+            var bigInt = new BigInteger(value.Value, isBigEndian: true, isUnsigned: false);
+            return (decimal)bigInt / (decimal)Math.Pow(10, value.Scale);
+        }
+
+        public PDecimalValue ConvertPDecimalValue(decimal value)
+        {
+            uint fixedPrecision = 10;
+            uint fixedScale = 10;
+
+            var scaledDecimal = value * (decimal)Math.Pow(10, fixedScale);
+            var bigInt = new BigInteger(scaledDecimal);
+            var valueBytes = bigInt.ToByteArray(isBigEndian: true, isUnsigned: false);
+
+            return new PDecimalValue
+            {
+                Scale = fixedScale,
+                Precision = fixedPrecision,
+                Value = valueBytes
+            };
         }
 
         public bool IsSharesZero(double shares)

--- a/source/PortfolioReader.Test/Protobuf/PortfolioProtobufDataConverterTest.cs
+++ b/source/PortfolioReader.Test/Protobuf/PortfolioProtobufDataConverterTest.cs
@@ -24,5 +24,25 @@ namespace Toqe.PortfolioReader.Test.Protobuf
             Assert.Equal(0.6792716849m, convertedValue);
             Assert.Equal(1.4722m, Math.Round(1 / convertedValue, 4, MidpointRounding.AwayFromZero));
         }
+
+        [Fact]
+        public void TestPDecimalToDecimalValueConversion()
+        {
+            var converter = new PortfolioProtobufDataConverter();
+            uint fixedPrecision = 10;
+            uint fixedScale = 10;
+
+            var value = 0.8804366966m;
+            var convertedValue = converter.ConvertPDecimalValue(value);
+            Assert.Equal(fixedPrecision, convertedValue.Precision);
+            Assert.Equal(fixedScale, convertedValue.Scale);
+            Assert.Equal(new byte[] { 2, 12, 199, 250, 118 }, convertedValue.Value);
+
+            value = 0.6792716849m;
+            convertedValue = converter.ConvertPDecimalValue(value);
+            Assert.Equal(fixedPrecision, convertedValue.Precision);
+            Assert.Equal(fixedScale, convertedValue.Scale);
+            Assert.Equal(new byte[] { 1, 148, 224, 162, 49 }, convertedValue.Value);
+        }
     }
 }


### PR DESCRIPTION
Increase .net standard from 2.0 to 2.1 to be able to use isBigEndian overload of BigInteger constructor